### PR TITLE
Add config option for REDIRECT_EXTRA_PATH_MODE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* Add config option for `REDIRECT_EXTRA_PATH_MODE`
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* Deprecate `AppendExtraPathConfigOption`.
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [9.3.0] - 2024-11-24
 ### Added
 * *Nothing*

--- a/config/config.php
+++ b/config/config.php
@@ -60,6 +60,7 @@ return [
                 'URL shortener > Auto resolve titles'
                     => Config\Option\UrlShortener\AutoResolveTitlesConfigOption::class,
                 'URL shortener > Append extra path' => Config\Option\UrlShortener\AppendExtraPathConfigOption::class,
+                'URL shortener > Extra path mode' => Config\Option\UrlShortener\ExtraPathModeConfigOption::class,
                 'URL shortener > Multi-segment slugs'
                     => Config\Option\UrlShortener\EnableMultiSegmentSlugsConfigOption::class,
                 'URL shortener > Trailing slashes' => Config\Option\UrlShortener\EnableTrailingSlashConfigOption::class,
@@ -149,6 +150,7 @@ return [
             Config\Option\UrlShortener\ShortDomainSchemaConfigOption::class => InvokableFactory::class,
             Config\Option\UrlShortener\AutoResolveTitlesConfigOption::class => InvokableFactory::class,
             Config\Option\UrlShortener\AppendExtraPathConfigOption::class => InvokableFactory::class,
+            Config\Option\UrlShortener\ExtraPathModeConfigOption::class => InvokableFactory::class,
             Config\Option\UrlShortener\EnableMultiSegmentSlugsConfigOption::class => InvokableFactory::class,
             Config\Option\UrlShortener\EnableTrailingSlashConfigOption::class => InvokableFactory::class,
             Config\Option\UrlShortener\ShortUrlModeConfigOption::class => InvokableFactory::class,

--- a/src/Config/Option/UrlShortener/AppendExtraPathConfigOption.php
+++ b/src/Config/Option/UrlShortener/AppendExtraPathConfigOption.php
@@ -7,6 +7,7 @@ namespace Shlinkio\Shlink\Installer\Config\Option\UrlShortener;
 use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated */
 class AppendExtraPathConfigOption extends BaseConfigOption
 {
     public function getEnvVar(): string

--- a/src/Config/Option/UrlShortener/ExtraPathModeConfigOption.php
+++ b/src/Config/Option/UrlShortener/ExtraPathModeConfigOption.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Installer\Config\Option\UrlShortener;
+
+use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class ExtraPathModeConfigOption extends BaseConfigOption
+{
+    public const MODES = [
+        'default' => 'Match strictly',
+        'append' => 'Append extra path',
+        'ignore' => 'Discard extra path',
+    ];
+
+    public function getEnvVar(): string
+    {
+        return 'REDIRECT_EXTRA_PATH_MODE';
+    }
+
+    public function ask(StyleInterface $io, array $currentOptions): string
+    {
+        return $io->choice(
+            question: <<<QUESTION
+            Do you want Shlink to redirect short URLs as soon as the first segment of the path matches a short code?
+
+              append:
+                * {shortDomain}/{shortCode}/[...extraPath] -> {longUrl}/[...extraPath]
+                * https://s.test/abc123                    -> https://www.example.com
+                * https://s.test/abc123/shlinkio           -> https://www.example.com/shlinkio
+
+              ignore:
+                * {shortDomain}/{shortCode}/[...extraPath] -> {longUrl}
+                * https://s.test/abc123                    -> https://www.example.com
+                * https://s.test/abc123/shlinkio           -> https://www.example.com
+
+
+            QUESTION,
+            choices: self::MODES,
+            default: 'default',
+        );
+    }
+}

--- a/src/Config/Option/UrlShortener/ShortUrlModeConfigOption.php
+++ b/src/Config/Option/UrlShortener/ShortUrlModeConfigOption.php
@@ -25,14 +25,13 @@ class ShortUrlModeConfigOption extends BaseConfigOption
 
     public function ask(StyleInterface $io, array $currentOptions): string
     {
-        $options = self::MODES;
         return $io->choice(
             'How do you want short URLs to be matched?'
             . PHP_EOL
             . '<options=bold;fg=yellow> Warning!</> <comment>This feature is experimental. It only applies to public '
             . 'routes (short URLs and QR codes). REST API routes always use strict match.</comment>'
             . PHP_EOL,
-            $options,
+            self::MODES,
             'strict',
         );
     }

--- a/test/Config/Option/UrlShortener/ExtraPathModeConfigOptionTest.php
+++ b/test/Config/Option/UrlShortener/ExtraPathModeConfigOptionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkioTest\Shlink\Installer\Config\Option\UrlShortener;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Shlinkio\Shlink\Installer\Config\Option\UrlShortener\ExtraPathModeConfigOption;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class ExtraPathModeConfigOptionTest extends TestCase
+{
+    private ExtraPathModeConfigOption $configOption;
+
+    public function setUp(): void
+    {
+        $this->configOption = new ExtraPathModeConfigOption();
+    }
+
+    #[Test]
+    public function returnsExpectedEnvVar(): void
+    {
+        self::assertEquals('REDIRECT_EXTRA_PATH_MODE', $this->configOption->getEnvVar());
+    }
+
+    #[Test, DataProvider('provideChoices')]
+    public function expectedQuestionIsAsked(string $choice): void
+    {
+        $io = $this->createMock(StyleInterface::class);
+        $io->expects($this->once())->method('choice')->with(
+            <<<QUESTION
+            Do you want Shlink to redirect short URLs as soon as the first segment of the path matches a short code?
+
+              append:
+                * {shortDomain}/{shortCode}/[...extraPath] -> {longUrl}/[...extraPath]
+                * https://s.test/abc123                    -> https://www.example.com
+                * https://s.test/abc123/shlinkio           -> https://www.example.com/shlinkio
+
+              ignore:
+                * {shortDomain}/{shortCode}/[...extraPath] -> {longUrl}
+                * https://s.test/abc123                    -> https://www.example.com
+                * https://s.test/abc123/shlinkio           -> https://www.example.com
+
+
+            QUESTION,
+            ExtraPathModeConfigOption::MODES,
+            'default',
+        )->willReturn($choice);
+
+        $answer = $this->configOption->ask($io, []);
+
+        self::assertEquals($choice, $answer);
+    }
+
+    public static function provideChoices(): iterable
+    {
+        foreach (ExtraPathModeConfigOption::MODES as $mode => $_) {
+            yield $mode => [$mode];
+        }
+    }
+}


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/2265

Add a config option to set `REDIRECT_EXTRA_PATH_MODE`.

Deprecate the `AppendExtraPathConfigOption`, which will be soon removed.