### PR TITLE
Mark all QR-code-related options as deprecated

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -86,7 +86,7 @@ return [
                 'Redirects > Invalid short URL' => Config\Option\Redirect\InvalidShortUrlRedirectConfigOption::class,
                 'Redirects > Regular 404' => Config\Option\Redirect\Regular404RedirectConfigOption::class,
             ],
-            'QR CODES' => [
+            'QR CODES [DEPRECATED]' => [
                 'QR codes > Default size' => Config\Option\QrCode\DefaultSizeConfigOption::class,
                 'QR codes > Default margin' => Config\Option\QrCode\DefaultMarginConfigOption::class,
                 'QR codes > Default format' => Config\Option\QrCode\DefaultFormatConfigOption::class,

--- a/src/Config/Option/QrCode/DefaultBgColorConfigOption.php
+++ b/src/Config/Option/QrCode/DefaultBgColorConfigOption.php
@@ -8,6 +8,7 @@ use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Shlinkio\Shlink\Installer\Config\Util\ConfigOptionsValidator;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated Shlink has deprecated support for QR codes */
 class DefaultBgColorConfigOption extends BaseConfigOption
 {
     public function getEnvVar(): string

--- a/src/Config/Option/QrCode/DefaultColorConfigOption.php
+++ b/src/Config/Option/QrCode/DefaultColorConfigOption.php
@@ -8,6 +8,7 @@ use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Shlinkio\Shlink\Installer\Config\Util\ConfigOptionsValidator;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated Shlink has deprecated support for QR codes */
 class DefaultColorConfigOption extends BaseConfigOption
 {
     public function getEnvVar(): string

--- a/src/Config/Option/QrCode/DefaultErrorCorrectionConfigOption.php
+++ b/src/Config/Option/QrCode/DefaultErrorCorrectionConfigOption.php
@@ -7,9 +7,10 @@ namespace Shlinkio\Shlink\Installer\Config\Option\QrCode;
 use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated Shlink has deprecated support for QR codes */
 class DefaultErrorCorrectionConfigOption extends BaseConfigOption
 {
-    private const SUPPORTED_ERROR_CORRECTIONS = [
+    private const array SUPPORTED_ERROR_CORRECTIONS = [
         'l' => 'Low',
         'm' => 'Medium',
         'q' => 'Quartile',

--- a/src/Config/Option/QrCode/DefaultFormatConfigOption.php
+++ b/src/Config/Option/QrCode/DefaultFormatConfigOption.php
@@ -7,9 +7,10 @@ namespace Shlinkio\Shlink\Installer\Config\Option\QrCode;
 use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated Shlink has deprecated support for QR codes */
 class DefaultFormatConfigOption extends BaseConfigOption
 {
-    private const SUPPORTED_FORMATS = ['png', 'svg'];
+    private const array SUPPORTED_FORMATS = ['png', 'svg'];
 
     public function getEnvVar(): string
     {

--- a/src/Config/Option/QrCode/DefaultLogoUrlConfigOption.php
+++ b/src/Config/Option/QrCode/DefaultLogoUrlConfigOption.php
@@ -8,6 +8,7 @@ use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Shlinkio\Shlink\Installer\Config\Util\ConfigOptionsValidator;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated Shlink has deprecated support for QR codes */
 class DefaultLogoUrlConfigOption extends BaseConfigOption
 {
     public function getEnvVar(): string

--- a/src/Config/Option/QrCode/DefaultMarginConfigOption.php
+++ b/src/Config/Option/QrCode/DefaultMarginConfigOption.php
@@ -8,6 +8,7 @@ use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Shlinkio\Shlink\Installer\Config\Util\ConfigOptionsValidator;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated Shlink has deprecated support for QR codes */
 class DefaultMarginConfigOption extends BaseConfigOption
 {
     public function getEnvVar(): string

--- a/src/Config/Option/QrCode/DefaultRoundBlockSizeConfigOption.php
+++ b/src/Config/Option/QrCode/DefaultRoundBlockSizeConfigOption.php
@@ -7,10 +7,11 @@ namespace Shlinkio\Shlink\Installer\Config\Option\QrCode;
 use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated Shlink has deprecated support for QR codes */
 class DefaultRoundBlockSizeConfigOption extends BaseConfigOption
 {
-    private const YES = 'yes';
-    private const NO = 'no';
+    private const string YES = 'yes';
+    private const string NO = 'no';
 
     public function getEnvVar(): string
     {

--- a/src/Config/Option/QrCode/DefaultSizeConfigOption.php
+++ b/src/Config/Option/QrCode/DefaultSizeConfigOption.php
@@ -8,10 +8,11 @@ use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Shlinkio\Shlink\Installer\Config\Util\ConfigOptionsValidator;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated Shlink has deprecated support for QR codes */
 class DefaultSizeConfigOption extends BaseConfigOption
 {
-    private const MIN_SIZE = 50;
-    private const MAX_SIZE = 1000;
+    private const int MIN_SIZE = 50;
+    private const int MAX_SIZE = 1000;
 
     public function getEnvVar(): string
     {

--- a/src/Config/Option/QrCode/EnabledForDisabledShortUrlsConfigOption.php
+++ b/src/Config/Option/QrCode/EnabledForDisabledShortUrlsConfigOption.php
@@ -7,6 +7,7 @@ namespace Shlinkio\Shlink\Installer\Config\Option\QrCode;
 use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
 use Symfony\Component\Console\Style\StyleInterface;
 
+/** @deprecated Shlink has deprecated support for QR codes */
 class EnabledForDisabledShortUrlsConfigOption extends BaseConfigOption
 {
     public function getEnvVar(): string


### PR DESCRIPTION
Shlink [has deprecated](https://github.com/shlinkio/shlink/issues/2408) support for QR codes, so marking all related options as deprecated here.