### PR TITLE
Add CORS-related config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 ## [Unreleased]
 ### Added
 * Add `REAL_TIME_UPDATES_TOPICS` config option.
+* Add CORS-related config options.
 
 ### Changed
 * Update to PHPUnit 12

--- a/config/config.php
+++ b/config/config.php
@@ -102,6 +102,11 @@ return [
                 'Robots.txt > allow all' => Config\Option\Robots\RobotsAllowAllShortUrlsConfigOption::class,
                 'Robots.txt > user agents' => Config\Option\Robots\RobotsUserAgentsConfigOption::class,
             ],
+            'CORS' => [
+                'CORS > Allow origin' => Config\Option\Cors\CorsAllowOriginConfigOption::class,
+                'CORS > Allow credentials' => Config\Option\Cors\CorsAllowCredentialsConfigOption::class,
+                'CORS > Max age' => Config\Option\Cors\CorsMaxAgeConfigOption::class,
+            ],
             'APPLICATION' => [
                 'Delete short URLs > Visits threshold' => Config\Option\Visit\VisitsThresholdConfigOption::class,
                 'Base path' => Config\Option\BasePathConfigOption::class,
@@ -189,6 +194,9 @@ return [
             Config\Option\UrlShortener\RedirectStatusCodeConfigOption::class => InvokableFactory::class,
             Config\Option\UrlShortener\RedirectCacheLifeTimeConfigOption::class => InvokableFactory::class,
             Config\Option\RealTimeUpdates\RealTimeUpdatesTopicsConfigOption::class => InvokableFactory::class,
+            Config\Option\Cors\CorsAllowOriginConfigOption::class => InvokableFactory::class,
+            Config\Option\Cors\CorsAllowCredentialsConfigOption::class => InvokableFactory::class,
+            Config\Option\Cors\CorsMaxAgeConfigOption::class => InvokableFactory::class,
             Config\Option\QrCode\DefaultSizeConfigOption::class => InvokableFactory::class,
             Config\Option\QrCode\DefaultMarginConfigOption::class => InvokableFactory::class,
             Config\Option\QrCode\DefaultFormatConfigOption::class => InvokableFactory::class,

--- a/src/Config/Option/Cors/CorsAllowCredentialsConfigOption.php
+++ b/src/Config/Option/Cors/CorsAllowCredentialsConfigOption.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Installer\Config\Option\Cors;
+
+use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class CorsAllowCredentialsConfigOption extends BaseConfigOption
+{
+    public function getEnvVar(): string
+    {
+        return 'CORS_ALLOW_CREDENTIALS';
+    }
+
+    public function ask(StyleInterface $io, array $currentOptions): bool
+    {
+        return $io->confirm(
+            'Do you want browsers to forward credentials to your Shlink server during CORS requests?',
+            default: false,
+        );
+    }
+}

--- a/src/Config/Option/Cors/CorsAllowOriginConfigOption.php
+++ b/src/Config/Option/Cors/CorsAllowOriginConfigOption.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Installer\Config\Option\Cors;
+
+use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class CorsAllowOriginConfigOption extends BaseConfigOption
+{
+    public function getEnvVar(): string
+    {
+        return 'CORS_ALLOW_ORIGIN';
+    }
+
+    public function ask(StyleInterface $io, array $currentOptions): string
+    {
+        $answer = $io->choice(
+            'How do you want Shlink to determine which origins are allowed for CORS requests?',
+            [
+                '*' => 'All hosts are implicitly allowed (Access-Control-Allow-Origin is set to "*")',
+                '<origin>' =>
+                    'All hosts are explicitly allowed (Access-Control-Allow-Origin is set to the value in request\'s '
+                    . 'Origin header)',
+                'allowlist' => 'Provide a list of hosts that are allowed',
+            ],
+            '*'
+        );
+
+        return $answer !== 'allowlist' ? $answer : $io->ask(
+            'Provide a comma-separated list of origins that should be allowed to perform CORS requests to Shlink',
+        );
+    }
+}

--- a/src/Config/Option/Cors/CorsAllowOriginConfigOption.php
+++ b/src/Config/Option/Cors/CorsAllowOriginConfigOption.php
@@ -25,7 +25,7 @@ class CorsAllowOriginConfigOption extends BaseConfigOption
                     . 'Origin header)',
                 'allowlist' => 'Provide a list of hosts that are allowed',
             ],
-            '*'
+            '*',
         );
 
         return $answer !== 'allowlist' ? $answer : $io->ask(

--- a/src/Config/Option/Cors/CorsMaxAgeConfigOption.php
+++ b/src/Config/Option/Cors/CorsMaxAgeConfigOption.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Installer\Config\Option\Cors;
+
+use Shlinkio\Shlink\Installer\Config\Option\BaseConfigOption;
+use Shlinkio\Shlink\Installer\Config\Util\ConfigOptionsValidator;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class CorsMaxAgeConfigOption extends BaseConfigOption
+{
+    public function getEnvVar(): string
+    {
+        return 'CORS_MAX_AGE';
+    }
+
+    public function ask(StyleInterface $io, array $currentOptions): int
+    {
+        return $io->ask(
+            'How long (in seconds) do you want CORS config to be cached by browsers?',
+            '3600',
+            ConfigOptionsValidator::validatePositiveNumber(...),
+        );
+    }
+}

--- a/test/Config/Option/Cors/CorsAllowCredentialsConfigOptionTest.php
+++ b/test/Config/Option/Cors/CorsAllowCredentialsConfigOptionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkioTest\Shlink\Installer\Config\Option\Cors;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Shlinkio\Shlink\Installer\Config\Option\Cors\CorsAllowCredentialsConfigOption;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class CorsAllowCredentialsConfigOptionTest extends TestCase
+{
+    private CorsAllowCredentialsConfigOption $configOption;
+
+    public function setUp(): void
+    {
+        $this->configOption = new CorsAllowCredentialsConfigOption();
+    }
+
+    #[Test]
+    public function expectedEnvVarIsReturned(): void
+    {
+        self::assertEquals('CORS_ALLOW_CREDENTIALS', $this->configOption->getEnvVar());
+    }
+
+    #[Test]
+    public function expectedQuestionIsAsked(): void
+    {
+        $expectedAnswer = true;
+        $io = $this->createMock(StyleInterface::class);
+        $io->expects($this->once())->method('confirm')->with(
+            'Do you want browsers to forward credentials to your Shlink server during CORS requests?',
+            false,
+        )->willReturn($expectedAnswer);
+
+        $answer = $this->configOption->ask($io, []);
+
+        self::assertEquals($expectedAnswer, $answer);
+    }
+}

--- a/test/Config/Option/Cors/CorsAllowOriginConfigOptionTest.php
+++ b/test/Config/Option/Cors/CorsAllowOriginConfigOptionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkioTest\Shlink\Installer\Config\Option\Cors;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Shlinkio\Shlink\Installer\Config\Option\Cors\CorsAllowOriginConfigOption;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class CorsAllowOriginConfigOptionTest extends TestCase
+{
+    private CorsAllowOriginConfigOption $configOption;
+
+    public function setUp(): void
+    {
+        $this->configOption = new CorsAllowOriginConfigOption();
+    }
+
+    #[Test]
+    public function expectedEnvVarIsReturned(): void
+    {
+        self::assertEquals('CORS_ALLOW_ORIGIN', $this->configOption->getEnvVar());
+    }
+
+    #[Test]
+    #[TestWith(['*'])]
+    #[TestWith(['<origin>'])]
+    public function answerReturnedAsIsWhenNoAllowlistIsSelected(string $answer): void
+    {
+        $io = $this->createMock(StyleInterface::class);
+        $io->expects($this->once())->method('choice')->with(
+            'How do you want Shlink to determine which origins are allowed for CORS requests?',
+            [
+                '*' => 'All hosts are implicitly allowed (Access-Control-Allow-Origin is set to "*")',
+                '<origin>' =>
+                    'All hosts are explicitly allowed (Access-Control-Allow-Origin is set to the value in request\'s '
+                    . 'Origin header)',
+                'allowlist' => 'Provide a list of hosts that are allowed',
+            ],
+            '*',
+        )->willReturn($answer);
+        $io->expects($this->never())->method('ask');
+
+        self::assertEquals($answer, $this->configOption->ask($io, []));
+    }
+
+    #[Test]
+    public function allowListAskedWhenSelected(): void
+    {
+        $io = $this->createMock(StyleInterface::class);
+        $io->method('choice')->willReturn('allowlist');
+        $io->expects($this->once())->method('ask')->willReturn('foo,bar,baz');
+
+        self::assertEquals('foo,bar,baz', $this->configOption->ask($io, []));
+    }
+}

--- a/test/Config/Option/Cors/CorsMaxAgeConfigOptionTest.php
+++ b/test/Config/Option/Cors/CorsMaxAgeConfigOptionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkioTest\Shlink\Installer\Config\Option\Cors;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Shlinkio\Shlink\Installer\Config\Option\Cors\CorsMaxAgeConfigOption;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class CorsMaxAgeConfigOptionTest extends TestCase
+{
+    private CorsMaxAgeConfigOption $configOption;
+
+    public function setUp(): void
+    {
+        $this->configOption = new CorsMaxAgeConfigOption();
+    }
+
+    #[Test]
+    public function expectedEnvVarIsReturned(): void
+    {
+        self::assertEquals('CORS_MAX_AGE', $this->configOption->getEnvVar());
+    }
+
+    #[Test]
+    public function expectedQuestionIsAsked(): void
+    {
+        $expectedAnswer = 60;
+        $io = $this->createMock(StyleInterface::class);
+        $io->expects($this->once())->method('ask')->with(
+            'How long (in seconds) do you want CORS config to be cached by browsers?',
+            '3600',
+            $this->anything(),
+        )->willReturn($expectedAnswer);
+
+        $answer = $this->configOption->ask($io, []);
+
+        self::assertEquals($expectedAnswer, $answer);
+    }
+}


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/2418

Add `CORS_ALLOW_ORIGIN`, `CORS_ALLOW_CREDENTIALS` and `CORS_MAX_AGE` config options.